### PR TITLE
Fold every enviroment looking for \begin{ and \end{ pairs

### DIFF
--- a/after/ftplugin/tex.vim
+++ b/after/ftplugin/tex.vim
@@ -51,35 +51,11 @@ function! TeXFold(lnum)
         return '>3'
     endif
 
-    if line =~ '^\s*\\begin{frame'
+    if line =~ '^\s*\\begin{'
         return 'a1'
     endif
 
-    if line =~ '^\s*\\end{frame'
-        return 's1'
-    endif
-
-    if line =~ '^\s*\\begin{tabular'
-        return 'a1'
-    endif
-
-    if line =~ '^\s*\\end{tabular'
-        return 's1'
-    endif
-
-    if line =~ '^\s*\\begin{figure'
-        return 'a1'
-    endif
-
-    if line =~ '^\s*\\end{figure'
-        return 's1'
-    endif
-
-    if line =~ '^\s*\\begin{align'
-        return 'a1'
-    endif
-
-    if line =~ '^\s*\\end{align'
+    if line =~ '^\s*\\end{'
         return 's1'
     endif
 


### PR DESCRIPTION
It is easier to fold all enviroments this way.
However, your solution might be better, since it is easier to add the enviroments you want to fold, while my solution folds everything.
