### PR TITLE
tex_fold_use_default_envs option

### DIFF
--- a/after/ftplugin/tex.vim
+++ b/after/ftplugin/tex.vim
@@ -27,6 +27,10 @@ if !exists('g:tex_fold_additional_envs')
     let g:tex_fold_additional_envs = []
 endif
 
+if !exists('g:tex_fold_use_default_envs')
+    let g:tex_fold_use_default_envs = 1
+endif
+
 "}}}
 "{{{ Fold options
 
@@ -42,7 +46,9 @@ endif
 
 function! TeXFold(lnum)
     let line = getline(a:lnum)
-    let envs = '\(' . join(['frame', 'table', 'figure', 'align', 'lstlisting'] + g:tex_fold_additional_envs, '\|') . '\)'
+    let default_envs = g:tex_fold_use_default_envs?
+        \['frame', 'table', 'figure', 'align', 'lstlisting']: []
+    let envs = '\(' . join(default_envs + g:tex_fold_additional_envs, '\|') . '\)'
 
     if line =~ '^\s*\\section'
         return '>1'

--- a/doc/tex-fold.txt
+++ b/doc/tex-fold.txt
@@ -47,6 +47,12 @@ Per default, tex-fold folds figure, table, align, lstlisting and frame
 environments. If you want to fold more, you can list them with: >
     let g:tex_fold_additional_envs = ['example']
 <
+                                               *'g:tex_fold_use_default_envs'*
+Per default, tex-fold folds figure, table, align, lstlisting and frame
+environments. If you don't want to fold these environments, set this variable
+to 0: >
+    let g:tex_fold_use_default_envs = 0
+<
 
 ===============================================================================
 3. License                                                  *tex-fold-license*


### PR DESCRIPTION
Hi.

I think this plugin is very cool.

But now, maked `tex_fold_additional_envs`, thinking that in default only some environments are folded is odd, I think.

I think it is better that define the option that selects either using before folding or no environments are folded.