### PR TITLE
Improving compatibility with vim-latex-suite

### DIFF
--- a/after/ftplugin/tex.vim
+++ b/after/ftplugin/tex.vim
@@ -54,16 +54,24 @@ function! TeXFold(lnum)
         \['frame', 'table', 'figure', 'align', 'lstlisting']: []
     let envs = '\(' . join(default_envs + g:tex_fold_additional_envs, '\|') . '\)'
 
-    if line =~ '^\s*\\section'
+    if line =~ '^\s*\\chapter'
         return '>1'
     endif
 
-    if line =~ '^\s*\\subsection'
+    if line =~ '^\s*\\part'
         return '>2'
     endif
 
-    if line =~ '^\s*\\subsubsection'
+    if line =~ '^\s*\\section'
         return '>3'
+    endif
+
+    if line =~ '^\s*\\subsection'
+        return '>4'
+    endif
+
+    if line =~ '^\s*\\subsubsection'
+        return '>5'
     endif
 
     if !g:tex_fold_ignore_envs
@@ -92,12 +100,18 @@ endfunction
 function! TeXFoldText()
     let fold_line = getline(v:foldstart)
 
-    if fold_line =~ '^\s*\\\(sub\)*section'
+    if fold_line =~ '^\s*\\chapter'
+        let pattern = '\\chapter{\([^}]*\)}'
+        let repl = ' ' . g:tex_fold_sec_char . ' \1'
+    elseif fold_line =~ '^\s*\\part'
+        let pattern = '\\part{\([^}]*\)}'
+        let repl = ' ' . g:tex_fold_sec_char . ' \1'
+    elseif fold_line =~ '^\s*\\\(sub\)*section'
         let pattern = '\\\(sub\)*section{\([^}]*\)}'
         let repl = ' ' . g:tex_fold_sec_char . ' \2'
     elseif fold_line =~ '^\s*\\begin'
         let pattern = '\\begin{\([^}]*\)}'
-        let repl = ' ' . g:tex_fold_env_char . ' \1'
+        let repl = ' ' . g:tex_fold_env_char . ' \2'
     elseif fold_line =~ '^[^%]*%[^{]*{{{'
         let pattern = '^[^{]*{' . '{{\([.]*\)'
         let repl = '\1'

--- a/after/ftplugin/tex.vim
+++ b/after/ftplugin/tex.vim
@@ -85,11 +85,11 @@ function! TeXFold(lnum)
     endif
 
     if g:tex_fold_allow_marker
-        if line =~ '^[^%]*%[^{]*{{{'
+        if line =~ '^[^%]*%[^{]*STARTFOLD'
             return 'a1'
         endif
 
-        if line =~ '^[^%]*%[^}]*}}}'
+        if line =~ '^[^%]*%[^}]*ENDFOLD'
             return 's1'
         endif
     endif
@@ -112,7 +112,7 @@ function! TeXFoldText()
     elseif fold_line =~ '^\s*\\begin'
         let pattern = '\\begin{\([^}]*\)}'
         let repl = ' ' . g:tex_fold_env_char . ' \2'
-    elseif fold_line =~ '^[^%]*%[^{]*{{{'
+    elseif fold_line =~ '^[^%]*%[^{]*STARTFOLD'
         let pattern = '^[^{]*{' . '{{\([.]*\)'
         let repl = '\1'
     endif


### PR DESCRIPTION
The provided strings `{{{` and `}}}` for creating custom folds are not _compatible_ with [vim-latex-suite](http://vim-latex.sourceforge.net/), since `{{` maps to some macro. I propose to substitute them with the more naive `STARTFOLD` and `ENDFOLD`.

I also propose to add support for `\part` and `\chapter`. This plugin is particularly useful when editing large `.tex` files with [vim-latex-suite](http://vim-latex.sourceforge.net/): this is the case when writing books or thesis, which typically make use of `\part` and `\chapter`.  
