### PR TITLE
Modify TeXFoldText to deal with '*' in sections.

### DIFF
--- a/after/ftplugin/tex.vim
+++ b/after/ftplugin/tex.vim
@@ -93,7 +93,7 @@ function! TeXFoldText()
     let fold_line = getline(v:foldstart)
 
     if fold_line =~ '^\s*\\\(sub\)*section'
-        let pattern = '\\\(sub\)*section{\([^}]*\)}'
+        let pattern = '\\\(sub\)*section\*\={\([^}]*\)}'
         let repl = ' ' . g:tex_fold_sec_char . ' \2'
     elseif fold_line =~ '^\s*\\begin'
         let pattern = '\\begin{\([^}]*\)}'


### PR DESCRIPTION
Yeah, everything is in the title.
I made a small change so sections written like that "\section*{something}" would keep showing nicely.
The little '*' is for sections without a number showing.